### PR TITLE
Fix memory leak caused by a typo in RoundTrip()

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -45,7 +45,7 @@ func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
 	}
 	res.Body = &onEOFReader{
 		rc: res.Body,
-		fn: func() { t.setModReq(rc, nil) },
+		fn: func() { t.setModReq(r, nil) },
 	}
 	return res, nil
 }


### PR DESCRIPTION
There was a typo in the RoundTrip() function, the function called by onEOFReader was using the wrong parameter "rc" instead of "r".

This should fix #1, the memory leak was reproduceable in the application im working on and was fixed by this.