### PR TITLE
fix redirect bug

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -74,6 +74,9 @@ func (t *Transport) base() http.RoundTripper {
 // modifyRequest exchanges the HTTP request scheme, host, and userinfo
 // by the URL the connection returns.
 func modifyRequest(r *http.Request, conn Connection) error {
+	if r.URL.Scheme != "" {
+		return nil
+	}
 	url := conn.URL()
 	if url.Scheme != "" {
 		r.URL.Scheme = url.Scheme


### PR DESCRIPTION
there will throw an error "stopped after 10 redirects" when the server return http status 3xx with a location, which cause infinite loop:
for example, get http://master/file/1 returns 302 http://node1/file/1 and the balancer doesn't contains this host and will modify the host from node1 to master...